### PR TITLE
Mobile UX on Talks Page

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -17,6 +17,13 @@ h6 {
   display: none !important;
 }
 
+.hidden-mobile {
+  display: block !important;
+}
+.visible-mobile {
+  display: none !important;
+}
+
 @media print {
   .hidden-print {
     display: none !important;
@@ -27,6 +34,12 @@ h6 {
 }
 
 @media screen and (max-width: 480px) {
+  .hidden-mobile {
+    display: none !important;
+  }
+  .visible-mobile {
+    display: block !important;
+  }
   iframe {
     max-width: 100%;
     height: auto;

--- a/src/pages/talks.js
+++ b/src/pages/talks.js
@@ -34,14 +34,28 @@ class Talk extends React.Component {
           <a
             href={url}
             target="_blank"
-            style={{ marginBottom: embed ? rhythm(1) : 0, display: "block" }}
+            style={{
+              marginBottom: embed ? rhythm(1) : 0,
+              display: "block"
+            }}
           >
             {title}
           </a>
         </h3>
         <p>{description}</p>
         {embed ? (
+          <a
+            href={embed}
+            target="_blank"
+            className="visible-mobile"
+            style={{ marginBottom: rhythm(1), display: "block" }}
+          >
+            Watch the talk on Youtube
+          </a>
+        ) : null}
+        {embed ? (
           <div
+            className="hidden-mobile hidden-print"
             style={{
               height: 0,
               paddingBottom: "56.25%",
@@ -52,7 +66,6 @@ class Talk extends React.Component {
             ref={node => (this.iframeWrapper = node)}
           >
             <iframe
-              className="hidden-print"
               src={embed}
               frameBorder="0"
               allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
Enhances the mobile experience by:

- Add CSS class names specific to the mobile viewport
- Hide iframe embeds on mobile
- Adds a link to youtube page for the talks